### PR TITLE
Minor updates: build on Cray systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
-
 project(TMPIFile CXX)
 
 ##### PATH OF CMAKE PACKAGES
@@ -11,7 +10,7 @@ find_package(MPI REQUIRED)
 find_package(ROOT REQUIRED)
 
 if( NOT DEFINED MPI_INCLUDE_PATH )
-    set( MPI_INCLUDE_PATH "/home/yswang/TOOLS/mpich/include" )
+    set( MPI_INCLUDE_PATH "$ENV{MPICH_DIR}/include" )
 endif()
 
 # Set the install path if not set by -DCMAKE_INSTALL_PREFIX=...

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Create a **build** and an **install** directory:
 mkdir install build
 ```
 
+**Make sure to enable dynamic linking on Cray system before build:**
+```bash
+export CRAYPE_LINK_TYPE=dynamic
+```
+
 Go to the **build** directory and build CMake:
 ```bash
 cd build


### PR DESCRIPTION
do "export CRAYPE_LINK_TYPE=dynamic" before CMake build will enable dynamic linking. It works on Cori thus should solve the same issue on Theta.